### PR TITLE
Update KodiClient to use JSONRPC.Introspect

### DIFF
--- a/kodipydent/KodiClient.py
+++ b/kodipydent/KodiClient.py
@@ -20,18 +20,34 @@ base_hive = {
         'password': {
             'type': 'http_basic_auth',
             'optional': True
+        },
+        'jsonrpc': {
+            'value': '2.0',
+            'type': 'json_rpc'
+        },
+        'request_id': {
+            'type': 'json_rpc'
         }
     },
     'endpoints': {
         'rpc': {
             'path': '/jsonrpc',
+            'methods': ['POST']
         }
     },
     'objects': {
         'API': {
             'actions': {
                 'get': {
-                    'endpoint': 'rpc'
+                    'endpoint': 'rpc',
+                    'method': 'POST',
+                    'traverse': ['result'],
+                    'variables': {
+                        'method': {
+                            'value': 'JSONRPC.Introspect',
+                            'type': 'json_rpc'
+                        }
+                    }
                 }
             }
         }
@@ -57,7 +73,7 @@ def random_id_gen():
     return uuid.uuid4().hex
 
 def Kodi(hostname, username='kodi', password=None, port=8080):
-    get_rpc = API(base_hive, hostname=hostname, port=port, username=username, password=password)
+    get_rpc = API(base_hive, hostname=hostname, port=port, username=username, password=password, request_id=random_id_gen())
     hive = Hive(get_rpc.API.get())
     return API(
         hive,

--- a/kodipydent/KodiClient.py
+++ b/kodipydent/KodiClient.py
@@ -73,7 +73,14 @@ def random_id_gen():
     return uuid.uuid4().hex
 
 def Kodi(hostname, username='kodi', password=None, port=8080):
-    get_rpc = API(base_hive, hostname=hostname, port=port, username=username, password=password, request_id=random_id_gen())
+    get_rpc = API(
+        base_hive,
+        hostname=hostname,
+        port=port,
+        username=username,
+        password=password,
+        request_id=random_id_gen
+    )
     hive = Hive(get_rpc.API.get())
     return API(
         hive,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as req_file:
 
 setup(
     name = "kodipydent",
-    version = "0.2",
+    version = "0.3",
     packages = ['kodipydent'],
     author = "Jesse Shapiro",
     author_email = "jesse@jesseshapiro.net",


### PR DESCRIPTION
Ensure that the API description can always be retrieved.  Current master
branch of Kodi has swicthed to only allow HTTP POST requests for the
/jsonrpc path.  The current Kodi commits prevent even retrieving the API
description via a HTTP GET with no params.  Using a HTTP POST to get the
API description using the JSONRPC.Introspect method should work round
this until and even after the Kodi rework is resolved.